### PR TITLE
Fix UI layout: Change dish display from horizontal grid to vertical stack

### DIFF
--- a/src/features/menu/components/MenuDisplay.tsx
+++ b/src/features/menu/components/MenuDisplay.tsx
@@ -31,7 +31,7 @@ export function MenuDisplay({
         <p className="text-orange-600/80">AI が提案した栄養バランスの良い献立です</p>
       </div>
 
-      <div className="grid gap-8 md:grid-cols-3">
+      <div className="space-y-6">
         <DishCard dish={menu.mainDish} title="主菜" icon="🍖" />
         <DishCard dish={menu.sideDish} title="副菜" icon="🥗" />
         <DishCard dish={menu.soup} title="汁物" icon="🍲" />


### PR DESCRIPTION
## Summary
- Change MenuDisplay.tsx layout from horizontal grid to vertical stack
- Replace `grid gap-8 md:grid-cols-3` with `space-y-6` for better mobile-first design

## Changes
- **File**: `src/features/menu/components/MenuDisplay.tsx`
- **Change**: Grid layout → Vertical stack layout
- **Impact**: Improved readability and mobile responsiveness

## Screenshots
Before: Horizontal 3-column grid layout
After: Vertical stack layout with consistent spacing

## Test plan
- [x] Layout displays correctly on desktop
- [x] Layout is mobile-friendly
- [x] All dish cards (主菜・副菜・汁物) are properly aligned
- [x] Spacing between cards is consistent

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)